### PR TITLE
feat: add custom XSS security threshold

### DIFF
--- a/securai/src/main/java/com/nomaddeveloper/securai/SecuraiInterceptor.java
+++ b/securai/src/main/java/com/nomaddeveloper/securai/SecuraiInterceptor.java
@@ -41,20 +41,31 @@ public class SecuraiInterceptor implements Interceptor {
     private static final String TAG = SecuraiInterceptor.class.getSimpleName();
     private static final long LATCH_TIMEOUT = 5L;
     private static final int DEFAULT_LATCH_COUNT = 1;
-
+    private static final float DEFAULT_XSS_SECURITY_THRESHOLD = 0.8f;
     private final XSSClassifierHelper xssClassifierHelper;
     private final DeniedResponse deniedResponse;
 
     /**
-     * Constructs a new SecuraiInterceptor with custom denied response handling.
+     * Constructs a new SecuraiInterceptor with custom xss security threshold.
+     *
+     * @param context              The application context.
+     * @param loggingEnabled       {@code true} to enable logging, {@code false} to disable it.
+     * @param xssSecurityThreshold The security threshold, must be between 0 and 1.
+     */
+    public SecuraiInterceptor(@NonNull Context context, boolean loggingEnabled, float xssSecurityThreshold) {
+        SecuraiLogger.setLoggingEnabled(loggingEnabled);
+        this.xssClassifierHelper = new XSSClassifierHelper(context, xssSecurityThreshold);
+        this.deniedResponse = new DeniedResponseImpl();
+    }
+
+    /**
+     * Constructs a new SecuraiInterceptor with default xss security threshold.
      *
      * @param context        The application context.
      * @param loggingEnabled {@code true} to enable logging, {@code false} to disable it.
      */
     public SecuraiInterceptor(@NonNull Context context, boolean loggingEnabled) {
-        SecuraiLogger.setLoggingEnabled(loggingEnabled);
-        this.xssClassifierHelper = new XSSClassifierHelper(context);
-        this.deniedResponse = new DeniedResponseImpl();
+        this(context, loggingEnabled, DEFAULT_XSS_SECURITY_THRESHOLD);
     }
 
     @NonNull

--- a/securai/src/main/java/com/nomaddeveloper/securai/internal/model/SecuraiError.java
+++ b/securai/src/main/java/com/nomaddeveloper/securai/internal/model/SecuraiError.java
@@ -16,7 +16,8 @@ public enum SecuraiError {
     XSS_CLASSIFIER_NOT_INITIALIZED("XSS classifier is not initialized."),
     NO_FIELD_VALUE_PROVIDED("No field value provided for classification."),
     XSS_CATEGORY_MISSING("Category with index '1' (XSS) not found."),
-    SECURITY_THREAT_DETECTED("Request contains a security threat");
+    SECURITY_THREAT_DETECTED("Request contains a security threat"),
+    THRESHOLD_IS_NOT_IN_BOUND("Threshold must be between 0 and 1");
 
     private final String message;
 


### PR DESCRIPTION
Added the ability to set a custom XSS security threshold when initializing the `SecuraiInterceptor`. The default threshold is 0.8, but it can now be adjusted to meet different security requirements. The threshold value must be between 0 and 1, and an exception will be thrown if this condition is not met.