### PR TITLE
feat: SecuraiInterceptorBuilder for flexible configuration.

### DIFF
--- a/app/src/main/java/com/nomaddeveloper/example/securai/network/retrofit/RetrofitBuilder.java
+++ b/app/src/main/java/com/nomaddeveloper/example/securai/network/retrofit/RetrofitBuilder.java
@@ -4,8 +4,8 @@ import static com.nomaddeveloper.example.securai.SecuraiApp.getAppContext;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.nomaddeveloper.securai.SecuraiInterceptor;
 import com.nomaddeveloper.example.securai.service.TestService;
+import com.nomaddeveloper.securai.SecuraiInterceptorBuilder;
 
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -17,7 +17,10 @@ public class RetrofitBuilder {
         Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 
         OkHttpClient client = new OkHttpClient.Builder()
-                .addInterceptor(new SecuraiInterceptor(getAppContext(), true))
+                .addInterceptor(new SecuraiInterceptorBuilder(getAppContext())
+                        .setThreshold(0.6f)
+                        .setLoggingEnabled(true)
+                        .build())
                 .addInterceptor(new HttpLoggingInterceptor())
                 .build();
 

--- a/securai/src/main/java/com/nomaddeveloper/securai/SecuraiInterceptor.java
+++ b/securai/src/main/java/com/nomaddeveloper/securai/SecuraiInterceptor.java
@@ -9,8 +9,6 @@ import static com.nomaddeveloper.securai.internal.model.InterceptorMessage.SECUR
 import static com.nomaddeveloper.securai.internal.model.InterceptorMessage.SECURITY_THREAT_DETECTED;
 import static com.nomaddeveloper.securai.internal.model.InterceptorMessage.THREAD_INTERRUPTED;
 
-import android.content.Context;
-
 import androidx.annotation.NonNull;
 
 import com.nomaddeveloper.securai.annotation.Secured;
@@ -20,7 +18,6 @@ import com.nomaddeveloper.securai.internal.helper.XSSClassifierHelper;
 import com.nomaddeveloper.securai.internal.logger.SecuraiLogger;
 import com.nomaddeveloper.securai.internal.model.SecuraiResult;
 import com.nomaddeveloper.securai.internal.response.denied.DeniedResponse;
-import com.nomaddeveloper.securai.internal.response.denied.DeniedResponseImpl;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
@@ -41,31 +38,21 @@ public class SecuraiInterceptor implements Interceptor {
     private static final String TAG = SecuraiInterceptor.class.getSimpleName();
     private static final long LATCH_TIMEOUT = 5L;
     private static final int DEFAULT_LATCH_COUNT = 1;
-    private static final float DEFAULT_XSS_SECURITY_THRESHOLD = 0.8f;
     private final XSSClassifierHelper xssClassifierHelper;
     private final DeniedResponse deniedResponse;
 
     /**
-     * Constructs a new SecuraiInterceptor with custom xss security threshold.
+     * Constructs a new {@code SecuraiInterceptor} using the provided {@link SecuraiInterceptorBuilder}.
+     * This constructor initializes the interceptor with the configuration specified in the builder,
+     * including setting up logging, initializing the XSS classifier, and configuring the denied response handler.
      *
-     * @param context              The application context.
-     * @param loggingEnabled       {@code true} to enable logging, {@code false} to disable it.
-     * @param xssSecurityThreshold The security threshold, must be between 0 and 1.
+     * @param builder The {@link SecuraiInterceptorBuilder} containing the configuration for this interceptor.
+     *                Must not be null.
      */
-    public SecuraiInterceptor(@NonNull Context context, boolean loggingEnabled, float xssSecurityThreshold) {
-        SecuraiLogger.setLoggingEnabled(loggingEnabled);
-        this.xssClassifierHelper = new XSSClassifierHelper(context, xssSecurityThreshold);
-        this.deniedResponse = new DeniedResponseImpl();
-    }
-
-    /**
-     * Constructs a new SecuraiInterceptor with default xss security threshold.
-     *
-     * @param context        The application context.
-     * @param loggingEnabled {@code true} to enable logging, {@code false} to disable it.
-     */
-    public SecuraiInterceptor(@NonNull Context context, boolean loggingEnabled) {
-        this(context, loggingEnabled, DEFAULT_XSS_SECURITY_THRESHOLD);
+    SecuraiInterceptor(@NonNull SecuraiInterceptorBuilder builder) {
+        SecuraiLogger.setLoggingEnabled(builder.isLoggingEnabled());
+        this.xssClassifierHelper = new XSSClassifierHelper(builder.getContext(), builder.getThreshold());
+        this.deniedResponse = builder.getDeniedResponse();
     }
 
     @NonNull

--- a/securai/src/main/java/com/nomaddeveloper/securai/SecuraiInterceptorBuilder.java
+++ b/securai/src/main/java/com/nomaddeveloper/securai/SecuraiInterceptorBuilder.java
@@ -1,0 +1,132 @@
+package com.nomaddeveloper.securai;
+
+import static com.nomaddeveloper.securai.internal.model.SecuraiError.CONTEXT_MUST_NOT_BE_NULL;
+import static com.nomaddeveloper.securai.internal.model.SecuraiError.THRESHOLD_IS_NOT_IN_BOUND;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.nomaddeveloper.securai.internal.response.denied.DeniedResponse;
+import com.nomaddeveloper.securai.internal.response.denied.DeniedResponseImpl;
+import com.nomaddeveloper.securai.internal.exception.SecuraiException;
+
+import java.util.Objects;
+
+/**
+ * Builder class for creating instances of {@link SecuraiInterceptor}.
+ * <p>
+ * This class provides a fluent API to configure the settings of the {@link SecuraiInterceptor}
+ * before instantiation. It allows setting options such as logging enablement, threshold for
+ * security checks, and a custom denied response handler.
+ */
+public class SecuraiInterceptorBuilder {
+
+    private final Context context;
+    private boolean loggingEnabled = false;
+    private float threshold = 0.8f;
+    private DeniedResponse deniedResponse;
+
+    /**
+     * Constructs a new {@code SecuraiInterceptorBuilder} with the given application context.
+     *
+     * @param context The Android application context. Must not be null.
+     * @throws NullPointerException if the provided context is null.
+     */
+    public SecuraiInterceptorBuilder(@NonNull Context context) {
+        this.context = Objects.requireNonNull(context, CONTEXT_MUST_NOT_BE_NULL.getMessage());
+    }
+
+    /**
+     * Enables or disables logging of security-related information by the interceptor.
+     * When enabled, the interceptor will log details about the checks performed and their outcomes.
+     * This can be useful for debugging and understanding the interceptor's behavior.
+     *
+     * @param loggingEnabled {@code true} to enable logging, {@code false} to disable. Defaults to {@code false}.
+     * @return This {@code SecuraiInterceptorBuilder} instance for chaining method calls.
+     */
+    public SecuraiInterceptorBuilder setLoggingEnabled(boolean loggingEnabled) {
+        this.loggingEnabled = loggingEnabled;
+        return this;
+    }
+
+    /**
+     * Sets the threshold value for security checks.
+     * The threshold must be between 0.0 and 1.0, inclusive.
+     *
+     * @param threshold The threshold value between 0.0 and 1.0. Defaults to {@code 0.8f}.
+     * @return This {@code SecuraiInterceptorBuilder} instance for chaining method calls.
+     * @throws SecuraiException if the provided threshold is not within the valid range (0 to 1).
+     */
+    public SecuraiInterceptorBuilder setThreshold(float threshold) {
+        if (threshold < 0 || threshold > 1) {
+            throw new SecuraiException(THRESHOLD_IS_NOT_IN_BOUND.getMessage());
+        }
+        this.threshold = threshold;
+        return this;
+    }
+
+    /**
+     * Sets a custom {@link DeniedResponse} to be used when a request is denied by the interceptor.
+     * This allows for customization of the response returned to the client when a security check fails.
+     * If no custom {@code DeniedResponse} is provided, a default implementation will be used.
+     *
+     * @param deniedResponse The custom {@link DeniedResponse} implementation. Can be null to use the default.
+     * @return This {@code SecuraiInterceptorBuilder} instance for chaining method calls.
+     */
+    public SecuraiInterceptorBuilder setDeniedResponse(DeniedResponse deniedResponse) {
+        this.deniedResponse = deniedResponse;
+        return this;
+    }
+
+    /**
+     * Builds and returns a new instance of {@link SecuraiInterceptor} configured with the
+     * settings provided to this builder.
+     *
+     * @return A new {@link SecuraiInterceptor} instance.
+     */
+    public SecuraiInterceptor build() {
+        return new SecuraiInterceptor(this);
+    }
+
+    /**
+     * Retrieves the application context associated with this builder.
+     * This method is intended for internal use by the {@link SecuraiInterceptor} during its initialization.
+     *
+     * @return The Android application context.
+     */
+    Context getContext() {
+        return context;
+    }
+
+    /**
+     * Retrieves the logging enabled status configured in this builder.
+     * This method is intended for internal use by the {@link SecuraiInterceptor}.
+     *
+     * @return {@code true} if logging is enabled, {@code false} otherwise.
+     */
+    boolean isLoggingEnabled() {
+        return loggingEnabled;
+    }
+
+    /**
+     * Retrieves the threshold value configured in this builder.
+     * This method is intended for internal use by the {@link SecuraiInterceptor}.
+     *
+     * @return The threshold value.
+     */
+    float getThreshold() {
+        return threshold;
+    }
+
+    /**
+     * Retrieves the {@link DeniedResponse} configured in this builder.
+     * If no custom {@code DeniedResponse} was set, this method returns a default implementation.
+     * This method is intended for internal use by the {@link SecuraiInterceptor}.
+     *
+     * @return The configured {@link DeniedResponse} or a default instance.
+     */
+    DeniedResponse getDeniedResponse() {
+        return deniedResponse != null ? deniedResponse : new DeniedResponseImpl();
+    }
+}

--- a/securai/src/main/java/com/nomaddeveloper/securai/internal/helper/XSSClassifierHelper.java
+++ b/securai/src/main/java/com/nomaddeveloper/securai/internal/helper/XSSClassifierHelper.java
@@ -13,7 +13,6 @@ import static com.nomaddeveloper.securai.internal.model.Field.BODY;
 import static com.nomaddeveloper.securai.internal.model.Field.HEADER;
 import static com.nomaddeveloper.securai.internal.model.Field.PARAM;
 import static com.nomaddeveloper.securai.internal.model.SecuraiError.NO_FIELD_VALUE_PROVIDED;
-import static com.nomaddeveloper.securai.internal.model.SecuraiError.THRESHOLD_IS_NOT_IN_BOUND;
 import static com.nomaddeveloper.securai.internal.model.SecuraiError.XSS_CATEGORY_MISSING;
 import static com.nomaddeveloper.securai.internal.model.SecuraiError.XSS_CLASSIFIER_INIT_FAILED;
 import static com.nomaddeveloper.securai.internal.model.SecuraiError.XSS_CLASSIFIER_NOT_INITIALIZED;
@@ -30,7 +29,6 @@ import com.google.mediapipe.tasks.core.BaseOptions;
 import com.google.mediapipe.tasks.text.textclassifier.TextClassifier;
 import com.google.mediapipe.tasks.text.textclassifier.TextClassifierResult;
 import com.nomaddeveloper.securai.internal.callback.ClassifyListener;
-import com.nomaddeveloper.securai.internal.exception.SecuraiException;
 import com.nomaddeveloper.securai.internal.logger.SecuraiLogger;
 import com.nomaddeveloper.securai.internal.model.Field;
 import com.nomaddeveloper.securai.internal.model.SecuraiRequest;
@@ -55,7 +53,7 @@ public class XSSClassifierHelper {
     private static final float DEFAULT_XSS_SCORE = -1f;
     private static final int CLASSIFICATION_RESULT_SIZE = 2;
     private final Context context;
-    private final float xssSecurityThreshold;
+    private final float threshold;
     private TextClassifier xssClassifier;
 
 
@@ -64,12 +62,9 @@ public class XSSClassifierHelper {
      *
      * @param context The application context used for loading the model.
      */
-    public XSSClassifierHelper(@NonNull Context context, float xssSecurityThreshold) {
+    public XSSClassifierHelper(@NonNull Context context, float threshold) {
         this.context = context;
-        if (xssSecurityThreshold < 0 || xssSecurityThreshold > 1) {
-            throw new SecuraiException(THRESHOLD_IS_NOT_IN_BOUND.getMessage());
-        }
-        this.xssSecurityThreshold = xssSecurityThreshold;
+        this.threshold = threshold;
         initClassifier();
     }
 
@@ -223,7 +218,7 @@ public class XSSClassifierHelper {
             return false;
         }
 
-        if (xssScore > xssSecurityThreshold) {
+        if (xssScore > threshold) {
             classifyListener.onThreatDetected(field, value);
             return true;
         }

--- a/securai/src/main/java/com/nomaddeveloper/securai/internal/model/SecuraiError.java
+++ b/securai/src/main/java/com/nomaddeveloper/securai/internal/model/SecuraiError.java
@@ -17,7 +17,8 @@ public enum SecuraiError {
     NO_FIELD_VALUE_PROVIDED("No field value provided for classification."),
     XSS_CATEGORY_MISSING("Category with index '1' (XSS) not found."),
     SECURITY_THREAT_DETECTED("Request contains a security threat"),
-    THRESHOLD_IS_NOT_IN_BOUND("Threshold must be between 0 and 1");
+    THRESHOLD_IS_NOT_IN_BOUND("Threshold must be between 0 and 1"),
+    CONTEXT_MUST_NOT_BE_NULL("Context must not be null.");
 
     private final String message;
 


### PR DESCRIPTION
Introduces `SecuraiInterceptorBuilder` for configuring `SecuraiInterceptor` instances with options like logging, threshold, and custom denied response. `SecuraiInterceptor` now uses the builder for initialization. Updates example app to use the new builder.
Adds `CONTEXT_MUST_NOT_BE_NULL` error.